### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,7 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: "release"
+      cortexEntityIdOrTag: service-azure-cli-credentials-proxy
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish.yml` file to include a new parameter for deployment configuration.

Workflow configuration update:

* Added the `cortexEntityIdOrTag` parameter with the value `service-azure-cli-credentials-proxy` to the `jobs:` section in the workflow file. This parameter is likely used to specify an entity or tag for deployment purposes.